### PR TITLE
Add parallel profiling with Neuron 2.21 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,28 @@
+# Python build artifacts
+*.py[cod]
+__pycache__/
+*.so
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Distribution / packaging
+.Python
+*.whl
+
 # Compiled source files
 *.pyc
 *.pyo
@@ -20,8 +45,6 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 *.sh
-*.txt
-*.pkl
 
 # Environments
 .env
@@ -46,13 +69,15 @@ Thumbs.db
 ehthumbs.db
 Desktop.ini
 
-# Misc
+# Misc / Data Files
 .DS_Store
 *.log
 *.csv
 *.tsv
 *.xlsx
 *.pdf
+*.txt
+*.pkl
 
 # Artifacts
 artifacts/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 matplotlib
+dill

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+# setup.py
+from setuptools import setup, find_packages
+
+setup(
+    name="nki-autotune",
+    version="0.1.0-alpha",
+    packages=find_packages(),
+)

--- a/src/autotune_kernel.py
+++ b/src/autotune_kernel.py
@@ -1,79 +1,107 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Union
-import pickle, subprocess
+from typing import List
+import multiprocessing, warnings, dill, pickle
+
+multiprocessing.reduction.ForkingPickler.dumps = dill.dumps
+from concurrent.futures import ProcessPoolExecutor
 from tqdm import tqdm
 from time import perf_counter
-from neuronxcc.starfish.penguin.targets.nki.TraceKernel import (
-    BaremetalKernel,
-    BenchmarkKernel,
-)
+from pprint import pformat
+from neuronxcc.starfish.penguin.targets.nki.NumpyKernel import BenchmarkKernel
+from neuronxcc.starfish.penguin.targets.nki.TraceKernel import decltensor
 
 from src.visualize import plot_tuning_results
 
 
-class AutotuneKernel(BaremetalKernel):
+class AutotuneKernel(BenchmarkKernel):
     """
     Compile and benchmark NKI kernel on NeuronDevice.
     """
 
     def __init__(
         self,
-        warmup=5,
-        iters=10,
-        device_count=1,
-        configs: Union[dict, List[dict]] = None,
+        configs: List[dict] = None,
+        warmup=2,
+        iters=5,
+        max_workers=None,
+        benchmark_machines=None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
-        self.warmup = warmup
-        self.iters = iters
-        self.device_count = device_count
-        self.perf_results = []
+        super().__init__(warmup=warmup, iters=iters, **kwargs)
         self.design_space = configs
+        self.max_workers = max_workers
+        self.perf_results = []
+        self.benchmark_machines = (
+            benchmark_machines if benchmark_machines is not None else ["localhost"]
+        )  # a list of instance used for remote benchmark, if it is none, use the current machine itself
+
+    def create_parameter(self, ctx, shape, dtype, name="", annotation=None):
+        return decltensor(shape, dtype)
 
     def __call__(self, *args, **kwargs):
-        total_configs = len(self.design_space)
-        start = perf_counter()
-        for i in tqdm(range(total_configs)):
-            configs = self.design_space[i]
-            latency = self.test_design(configs, args, kwargs)
-            time_elapsed = perf_counter() - start
-            self.perf_results.append(
-                {
-                    "configs": configs,
-                    "latency": latency,
-                    "time_elapsed": time_elapsed,
-                }
-            )
-            print(f"Progress: {i + 1}/{total_configs} configurations tested")
+        device_locks = {
+            machine: multiprocessing.Manager().Lock()
+            for machine in self.benchmark_machines
+        }
+
+        args = [
+            self._translate_param(ctx=None, o=a, name="", annotation=None) for a in args
+        ]
+        kwargs = {
+            k: self._translate_param(ctx=None, o=v, name=k, annotation=None)
+            for k, v in kwargs.items()
+        }
+
+        with ProcessPoolExecutor(max_workers=self.max_workers) as e:
+            all_instances = []
+            # TODO Evenly assign the benchmarking jobs to instances, can improve to dynamic allocation in the future
+            for config, machine in zip(
+                self.design_space,
+                self.benchmark_machines
+                * (len(self.design_space) // len(self.benchmark_machines) + 1),
+            ):
+                future = e.submit(
+                    test_design,
+                    func=self.func,
+                    grid=self.grid,
+                    args=args,
+                    kwargs=kwargs,
+                    configs=config,
+                    device_lock=device_locks[machine],
+                    warmup=self.warmup,
+                    iters=self.iters,
+                    device_count=self.device_count,
+                    benchmark_machine=machine,
+                )
+                all_instances.append((future, config))
+
+            total_configs = len(all_instances)
+            start = perf_counter()
+            for i in tqdm(range(total_configs), desc="Benchmarking configurations"):
+                future, config = all_instances[i]
+                try:
+                    latency_us = future.result()
+                except Exception as e:
+                    latency_us = float("inf")
+                    warnings.warn(
+                        f"Warning: failed for config {config}, reason: {e} ({type(e)})",
+                        category=RuntimeWarning,
+                        stacklevel=2,
+                    )
+                elapsed = perf_counter() - start
+                self.perf_results.append(
+                    {
+                        "configs": config,
+                        "latency": latency_us,
+                        "time_elapsed": elapsed,
+                    }
+                )
+
+        self.grid = ()
         self.post_tuning()
         return None  # the kernel output means nothing here
-
-    def test_design(self, configs, args, kwargs):
-        benchmark = BenchmarkKernel(
-            func=self.func,
-            warmup=self.warmup,
-            iters=self.iters,
-            device_count=self.device_count,
-        )
-        combined_kwargs = {**configs, **kwargs}
-        try:
-            benchmark(*args, **combined_kwargs)
-            latency = (
-                benchmark.benchmark_result.nc_latency.get_latency_percentile(99)
-                / 1000.0
-            )
-        except AssertionError as e:
-            print(f"Warning: failed for config {configs}, reason: {e}")
-            latency = float("inf")
-        except subprocess.CalledProcessError as e:
-            print(
-                f"Warning: Will fail if not running on a neuron device, failed for config {configs}, reason: {e}"
-            )
-            latency = float("inf")
-        return latency
 
     def post_tuning(self):
         assert self.perf_results, "No configs tested"
@@ -83,12 +111,35 @@ class AutotuneKernel(BaremetalKernel):
         )
         min_latency = best_result["latency"]
         min_config = best_result["configs"]
-        print(f"The best latency is {min_latency} for config {min_config}")
 
         # dump the performance logs
-        from pprint import pformat
-
-        with open(f"./perf_results.txt", "w") as f:
+        with open(f"./perf_results.log", "w") as f:
             f.write(pformat(self.perf_results))
+            f.write(f"\nThe best latency is {min_latency} us for config {min_config}")
         pickle.dump(self.perf_results, open(f"./perf_results.pkl", "wb"))
         plot_tuning_results(self.perf_results)
+
+
+def test_design(
+    func,
+    grid,
+    args,
+    kwargs,
+    configs,
+    device_lock,
+    warmup,
+    iters,
+    device_count,
+    benchmark_machine=None,
+):
+    benchmark = BenchmarkKernel(
+        func=func,
+        grid=grid,
+        warmup=warmup,
+        iters=iters,
+        device_count=device_count,
+        device_lock=device_lock,
+        benchmark_machine=benchmark_machine,
+    )
+    benchmark(*args, **configs, **kwargs)
+    return benchmark.benchmark_result.nc_latency.get_latency_percentile(99)

--- a/test/matmul.py
+++ b/test/matmul.py
@@ -3,12 +3,10 @@
 
 import neuronxcc.nki.language as nl
 import neuronxcc.nki.typing as nt
-import numpy as np
 from itertools import product
 import random
 
 from src.autotune_kernel import AutotuneKernel
-
 from src.kernels import nki_matmul_fully_optimized_
 
 
@@ -20,7 +18,7 @@ def get_autotune_configs():
         list: A list of dictionaries, each containing configuration parameters for TILES_IN_BLOCK_M,
                 TILES_IN_BLOCK_N, and TILES_IN_BLOCK_K.
     """
-    TILES_IN_BLOCK_M_options = [2, 4]
+    TILES_IN_BLOCK_M_options = [4]
     TILES_IN_BLOCK_N_options = [2, 4]
     TILES_IN_BLOCK_K_options = [2, 4]
     params = list(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update to Neuron 2.21 support. Add parallel compilation. Note that the profiling execution is still sequential.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
