### PR TITLE
Enable rmsnorm allocation tuning

### DIFF
--- a/src/autotune_kernel.py
+++ b/src/autotune_kernel.py
@@ -9,8 +9,8 @@ from concurrent.futures import ProcessPoolExecutor
 from tqdm import tqdm
 from time import perf_counter
 from pprint import pformat
-import neuronxcc.nki as nki
 
+from src.benchmark import test_design
 from src.visualize import plot_tuning_results
 
 
@@ -111,26 +111,3 @@ class Autotune:
             )
         pickle.dump(self.perf_results, open(f"./perf_results.pkl", "wb"))
         plot_tuning_results(self.perf_results)
-
-
-def test_design(
-    func,
-    args,
-    kwargs,
-    configs,
-    device_lock,
-    warmup,
-    iters,
-    benchmark_machine=None,
-):
-    print(f"func = {func}")
-    bench_func = nki.benchmark(
-        warmup=warmup,
-        iters=iters,
-        device_lock=device_lock,
-        benchmark_machine=benchmark_machine,
-    )(func)
-    bench_func(*args, **configs, **kwargs)
-    latency_res = bench_func.benchmark_result.nc_latency
-    p99 = latency_res.get_latency_percentile(99)
-    return p99

--- a/src/benchmark.py
+++ b/src/benchmark.py
@@ -1,0 +1,23 @@
+import neuronxcc.nki as nki
+
+
+def test_design(
+    func,
+    args,
+    kwargs,
+    configs,
+    device_lock,
+    warmup,
+    iters,
+    benchmark_machine=None,
+):
+    bench_func = nki.benchmark(
+        warmup=warmup,
+        iters=iters,
+        device_lock=device_lock,
+        benchmark_machine=benchmark_machine,
+    )(func)
+    bench_func(*args, **configs, **kwargs)
+    latency_res = bench_func.benchmark_result.nc_latency
+    p99 = latency_res.get_latency_percentile(99)
+    return p99

--- a/test/rmsnorm.py
+++ b/test/rmsnorm.py
@@ -15,8 +15,10 @@ from neuronxcc.nki import baremetal
 
 def get_autotune_configs():
     configs = [
-        {"multi_buffer": 1},
-        {"multi_buffer": 2},
+        {"hidden_buffer_degree": 1},
+        {"hidden_buffer_degree": 2},
+        {"hidden_buffer_degree": 4},
+        {"hidden_buffer_degree": 8},
     ]
     return configs
 
@@ -36,7 +38,7 @@ def cpu_golden_result(hidden, gamma, qkv_weights, dtype, do_norm=True):
     return qkv_out
 
 
-def verify():
+def verify(batch, seqlen, dim, d_head, hidden_buffer_degree):
     dtype = np.float16
     atol = 1e-2
     rtol = 1e-3
@@ -51,14 +53,20 @@ def verify():
     weights_dev = nl.static_cast(weights, dtype)
 
     numeric_func = baremetal(allocated_fused_rms_norm_qkv)
-    allocated_out = numeric_func(hidden_dev, weights_dev)
+    allocated_out = numeric_func(hidden_dev, weights_dev, hidden_buffer_degree)
     allocated_out = nl.static_cast(allocated_out, np.float32)
     match = allclose(allocated_out, golden_res, atol=atol, rtol=rtol, verbose=1)
-    print(f"Allocated kernel match: {match}")
+    print(
+        f"Allocated kernel match for hidden_buffer_degree {hidden_buffer_degree}: {match}"
+    )
 
 
 if __name__ == "__main__":
-    batch, seqlen, dim, d_head = 1, 1024, 2048, 64
+    batch, seqlen, dim, d_head = 1, 4096, 2048, 256
+    configs = get_autotune_configs()
+    for config in configs:
+        print(config)
+        verify(batch, seqlen, dim, d_head, config["hidden_buffer_degree"])
 
     hidden = nt.tensor[[batch, seqlen, dim], nl.bfloat16]
     weights = nt.tensor[[dim, d_head], nl.bfloat16]
@@ -67,7 +75,7 @@ if __name__ == "__main__":
         configs=get_autotune_configs(),
         warmup=2,
         iters=10,
-        max_workers=2,
+        max_workers=1,
         show_compiler_tb=True,
     )
     tuner(hidden, weights)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Manually rewrite the NKI rmsnorm kernel to take buffer degree as a meta parameter.
Add a CPU verification function to verify numerical accuracy.
Add autotune example code to tune the RMSNorm kernel buffer degree.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
